### PR TITLE
Emit supported button values if not previously done on init

### DIFF
--- a/moes-zigbee-scene-switch/src/init.lua
+++ b/moes-zigbee-scene-switch/src/init.lua
@@ -48,6 +48,11 @@ local endpoint_to_component_map = function(device, endpoint)
 end
 
 local device_init = function(driver, device, event)
+  for comp_id, comp in pairs(device.profile.components) do
+    if device:get_latest_state(comp_id, capabilities.button.ID, capabilities.button.supportedButtonValues.ID) == nil then
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed","held","double"}, {visibility = { displayed = false }}))
+    end
+  end
   device:set_component_to_endpoint_fn(component_to_endpoint_map)
   device:set_endpoint_to_component_fn(endpoint_to_component_map)
 end


### PR DESCRIPTION
Emitting these events will improve the device card in the app so instead of the super long list of potential button events that you can assign an action to, it will just list pressed, double, and held that are supported by the device.  Normally we would do this on the `added` lifecycle, but doing it this way will correct it for already joined devices as well.